### PR TITLE
Fix code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/jsonrpc/types/codec.go
+++ b/jsonrpc/types/codec.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"math"
+	"fmt"
 
 	"github.com/0xPolygonHermez/zkevm-node/encoding"
 	"github.com/0xPolygonHermez/zkevm-node/hex"
@@ -532,6 +534,9 @@ func stringToBatchNumber(str string) (BatchNumber, error) {
 	n, err := encoding.DecodeUint64orHex(&str)
 	if err != nil {
 		return 0, err
+	}
+	if n > math.MaxInt64 {
+		return 0, fmt.Errorf("value out of range for int64: %d", n)
 	}
 	return BatchNumber(n), nil
 }


### PR DESCRIPTION
Fixes [https://github.com/GloWE3/animated-invention/security/code-scanning/4](https://github.com/GloWE3/animated-invention/security/code-scanning/4)

To fix the problem, we need to ensure that the value returned by `encoding.DecodeUint64orHex` is within the bounds of an `int64` before converting it to a `BatchNumber`. This can be achieved by adding a bounds check after decoding the value and before performing the type conversion.

1. Modify the `stringToBatchNumber` function to include bounds checking.
2. Use the `math` package to define the maximum and minimum values for `int64`.
3. Return an error if the value is out of bounds.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
